### PR TITLE
Fix build configuration for Hatchling

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,3 +27,6 @@ duckduckgo-mcp-server = "duckduckgo_mcp_server.server:main"
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/duckduckgo_mcp_server"]


### PR DESCRIPTION
This fixes the build issue where Hatchling couldn't determine which files to include in the wheel. The solution is to explicitly specify the package location in the pyproject.toml configuration.